### PR TITLE
Fix where numpy would otherwise save indexes as floating values

### DIFF
--- a/opt/snobfit/python/SQSnobFit/_snobnan.py
+++ b/opt/snobfit/python/SQSnobFit/_snobnan.py
@@ -69,7 +69,7 @@ def snobnan(fnan, f, near, inew):
             ind = near[l,:]
 
             # eliminate neighbors with function value NaN
-            ind1 = numpy.array([])
+            ind1 = numpy.array([], dtype=int)
             for i in range(len(ind)):
                  if (find(fnan == ind[i])).size > 0:
                      ind1 = numpy.concatenate((ind1, [i]), 0)


### PR DESCRIPTION
If I use the example provided in the documentation, when considering nan values inside the evaluation of the objective function, it will crash:

Modified example script:
```
import numpy as np
from skquant.opt import minimize

# some interesting objective function to minimize
def objective_function(x):
    if x[0] < 0.8:
        return np.nan
    fv = np.inner(x, x)
    fv *= 1 + 0.1*np.sin(10*(x[0]+x[1]))
    return np.random.normal(fv, 0.01)

# create a numpy array of bounds, one (low, high) for each parameter
bounds = np.array([[-1, 1], [-1, 1]], dtype=float)

# budget (number of calls, assuming 1 count per call)
budget = 1000

# initial values for all parameters
x0 = np.array([0.9, 0.5])

# method can be ImFil, SnobFit, Orbit, NOMAD, or Bobyqa
result, history = \
minimize(objective_function, x0, bounds, budget, method='SnobFit', maxfail=np.inf)

print(result)
print(history.shape)
print(history)
```

Crashes when the change in this pull request is not applied:

```
Traceback (most recent call last):
  File "src/algorithm_snobfit.py", line 31, in <module>
    minimize(objective_function, x0, bounds, budget, method='SnobFit', maxfail=np.inf)
  File "/home/paran/miniconda3/envs/rlgpu/lib/python3.7/site-packages/skquant/opt/__init__.py", line 56, in minimize
    return optimizer.minimize(func, x0, bounds, budget, options, **optkwds)
  File "/home/paran/miniconda3/envs/rlgpu/lib/python3.7/site-packages/SQSnobFit/_snobfit.py", line 231, in minimize
    request, xbest, fbest = snobfit(x, vals, config)
  File "/home/paran/miniconda3/envs/rlgpu/lib/python3.7/site-packages/SQSnobFit/_snobfit.py", line 371, in snobfit
    f = snobnan(fnan, f, near, inew)
  File "/home/paran/miniconda3/envs/rlgpu/lib/python3.7/site-packages/SQSnobFit/_snobnan.py", line 78, in snobnan
    ind = numpy.delete(ind, ind1, 0)
  File "<__array_function__ internals>", line 6, in delete
  File "/home/paran/miniconda3/envs/rlgpu/lib/python3.7/site-packages/numpy/lib/function_base.py", line 4552, in delete
    keep[obj,] = False
IndexError: arrays used as indices must be of integer (or boolean) type
```


After the change:
```
(rlgpu) paran@pop-os:~/Dropbox/NTNU/11_constraints_encoding/code$ python src/algorithm_snobfit.py 
Optimal value: 0.627319, at parameters: [0.80196 0.26706]
(1001, 3)
[[ 1.17741086  0.9         0.5       ]
 [        nan -0.97276    -0.97716   ]
 [        nan -0.97138     0.97712   ]
 ...
 [        nan -0.85962    -0.62024   ]
 [        nan -0.46816    -0.88804   ]
 [        nan -0.4926      0.49562   ]]
```